### PR TITLE
Chore: Minor Improvements

### DIFF
--- a/packages/bootstrap/src/lib/cli.ts
+++ b/packages/bootstrap/src/lib/cli.ts
@@ -1,7 +1,7 @@
 import { Prompt } from '@effect/cli'
 import { Effect } from 'effect'
 
-export type CliArgs = {
+export type BootstrapArgs = {
   orgId: string
   billingAccountId: string
   folderName: string
@@ -37,7 +37,7 @@ const bucketName = Prompt.text({
 })
 
 const confirm = Prompt.confirm({
-  message: 'Can you please confirm?',
+  message: 'Do you want to proceed?',
 })
 
 export const prompts = Prompt.all({

--- a/packages/bootstrap/src/lib/services/CreateBucket.ts
+++ b/packages/bootstrap/src/lib/services/CreateBucket.ts
@@ -58,7 +58,9 @@ export class CreateBucket extends Context.Tag('CreateBucket')<
         }),
 
       deleteBucket: (bucket) =>
-        Effect.sync(() => execSync(`gcloud storage buckets delete ${bucket.uri}`)),
+        Effect.sync(() => execSync(`gcloud storage buckets delete ${bucket.uri}`)).pipe(
+          Effect.tap(() => Effect.log(`[CreateBucket] Deleted bucket "${bucket.uri}"`))
+        ),
     }
   })
 }

--- a/packages/bootstrap/src/lib/services/CreateFolder.ts
+++ b/packages/bootstrap/src/lib/services/CreateFolder.ts
@@ -7,6 +7,7 @@ export class CreateFolderError extends Data.TaggedError('CreateFolderError')<{
 
 export interface Folder {
   readonly id: string
+  readonly name?: string
 }
 
 export class CreateFolder extends Context.Tag('CreateFolder')<
@@ -37,11 +38,16 @@ export class CreateFolder extends Context.Tag('CreateFolder')<
 
           yield* Effect.log(`[CreateFolder] Created "${folderName}" folder`)
 
-          return { id: JSON.parse(String(output)).name.split('/').pop() }
+          return {
+            id: JSON.parse(String(output)).name.split('/').pop(),
+            name: folderName,
+          }
         }),
 
       deleteFolder: (folder) =>
-        Effect.sync(() => execSync(`gcloud resource-manager folders delete ${folder.id}`)),
+        Effect.sync(() => execSync(`gcloud resource-manager folders delete ${folder.id}`)).pipe(
+          Effect.tap(() => Effect.log(`[CreateFolder] Deleted folder "${folder.name}"`))
+        ),
     }
   })
 }

--- a/packages/bootstrap/src/lib/services/CreateProject.ts
+++ b/packages/bootstrap/src/lib/services/CreateProject.ts
@@ -6,10 +6,6 @@ export class CreateProjectError extends Data.TaggedError('CreateProjectError')<{
   readonly message: string
 }> {}
 
-export class DeleteProjectError extends Data.TaggedError('DeleteProjectError')<{
-  readonly message: string
-}> {}
-
 export interface Project {
   readonly id: string
   readonly name?: string
@@ -47,7 +43,9 @@ export class CreateProject extends Context.Tag('CreateProject')<
         }),
 
       deleteProject: (project) =>
-        Effect.sync(() => execSync(`gcloud projects delete ${project.id}`)),
+        Effect.sync(() => execSync(`gcloud projects delete ${project.id}`)).pipe(
+          Effect.tap(() => Effect.log(`[CreateProject] Deleted project "${project.name}"`))
+        ),
     }
   })
 }

--- a/packages/bootstrap/src/lib/services/EnableServices.ts
+++ b/packages/bootstrap/src/lib/services/EnableServices.ts
@@ -8,7 +8,7 @@ export class EnableServicesError extends Data.TaggedError('EnableServicesError')
 export class EnableServices extends Context.Tag('EnableServices')<
   EnableServices,
   {
-    readonly enable: (
+    readonly enableServices: (
       projectId: string,
       services: string[]
     ) => Effect.Effect<void, EnableServicesError>
@@ -16,7 +16,7 @@ export class EnableServices extends Context.Tag('EnableServices')<
 >() {
   static Live = Layer.sync(EnableServices, () => {
     return {
-      enable: (projectId: string, services: string[]) =>
+      enableServices: (projectId: string, services: string[]) =>
         Effect.gen(function* () {
           yield* Effect.log(`[EnableServices] Enabling services for project "${projectId}"`)
 
@@ -34,8 +34,8 @@ export class EnableServices extends Context.Tag('EnableServices')<
   })
 }
 
-export const enable = (projectId: string, services: string[]) =>
+export const enableServices = (projectId: string, services: string[]) =>
   Effect.gen(function* () {
-    const { enable } = yield* EnableServices
-    yield* enable(projectId, services)
+    const { enableServices } = yield* EnableServices
+    yield* enableServices(projectId, services)
   })

--- a/packages/bootstrap/src/lib/services/SetQuotaProject.ts
+++ b/packages/bootstrap/src/lib/services/SetQuotaProject.ts
@@ -30,12 +30,20 @@ export class SetQuotaProject extends Context.Tag('SetQuotaProject')<
             catch: () => new SetQuotaProjectError({ message: 'Failed to set quota project' }),
           })
 
+          yield* Effect.log(
+            `[SetQuotaProject] Set quota project to "${projectId}" (previous: "${currentProjectId}")`
+          )
+
           return { id: currentProjectId }
         }),
 
       setPreviousQuotaProject: (project) =>
         Effect.sync(() =>
           execSync(`gcloud auth application-default set-quota-project ${project.id}`)
+        ).pipe(
+          Effect.tap(() =>
+            Effect.log(`[SetQuotaProject] Set quota project back to "${project.id}"`)
+          )
         ),
     }
   })

--- a/packages/bootstrap/src/lib/services/index.ts
+++ b/packages/bootstrap/src/lib/services/index.ts
@@ -1,0 +1,7 @@
+export * from './CreateBucket'
+export * from './CreateFolder'
+export * from './CreateProject'
+export * from './EnableServices'
+export * from './LinkBillingAccount'
+export * from './SetCurrentProject'
+export * from './SetQuotaProject'

--- a/packages/bootstrap/src/lib/shared.ts
+++ b/packages/bootstrap/src/lib/shared.ts
@@ -11,3 +11,11 @@ export type FailureCaseLiterals =
   | undefined
 
 export class FailureCase extends Context.Tag('FailureCase')<FailureCase, FailureCaseLiterals>() {}
+
+export enum GcpService {
+  CloudBilling = 'cloudbilling.googleapis.com',
+  CloudResourceManager = 'cloudresourcemanager.googleapis.com',
+  Compute = 'compute.googleapis.com',
+  ServiceUsage = 'serviceusage.googleapis.com',
+  StorageComponent = 'storage-component.googleapis.com',
+}

--- a/packages/bootstrap/src/main.ts
+++ b/packages/bootstrap/src/main.ts
@@ -6,12 +6,12 @@ import { Effect, Logger } from 'effect'
 import { prompts } from './lib/cli'
 import { bootstrap } from './lib/bootstrap'
 
-const command = Command.prompt('bootstrap', prompts, (o) =>
-  o.confirm ? bootstrap(o) : Effect.logError('Operation cancelled.')
+const command = Command.prompt('bootstrap', prompts, (args) =>
+  args.confirm ? bootstrap(args) : Effect.logError('[Bootstrap] Operation cancelled.')
 )
 
 const cli = Command.run(command, {
-  name: 'GCP Bootstrap',
+  name: 'Bootstrap',
   version: '0.0.1',
 })
 


### PR DESCRIPTION
## Summary

Improved log messages and variables' names.

- Use `enum GcpService` instead of strings
- Use `Effect.log` on failure/rollback actions
- Use `import * as s from './services'` to namespace services
- Remove redundant `DeleteProjectError` and `GetCurrentProjectError` classes